### PR TITLE
Add currency conversion using exchange rate API

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Sara Vasquez
+ * Franchesca G
  */
 
 namespace App\Http\Controllers;
@@ -9,6 +9,7 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Models\Product;
 use App\Models\Review;
+use App\Utils\CurrencyConverter;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -49,10 +50,13 @@ class ProductController extends Controller
             ->orderBy('created_at', 'desc')
             ->get();
 
+        $convertedPrices = CurrencyConverter::convert($product->getPrice());
+
         $viewData = [
             'title' => $product->getTitle().' - '.__('app.products.show.title_suffix'),
             'product' => $product,
             'reviews' => $reviews,
+            'convertedPrices' => $convertedPrices,
         ];
 
         return view('product.show')->with('viewData', $viewData);

--- a/app/Utils/CurrencyConverter.php
+++ b/app/Utils/CurrencyConverter.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Franchesca Garcia
+ */
+
+namespace App\Utils;
+
+use Exception;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class CurrencyConverter
+{
+    private const API_URL = 'https://open.er-api.com/v6/latest/COP';
+
+    public static function convert(int $priceInCOP): array
+    {
+        try {
+            $response = Http::timeout(10)->get(self::API_URL);
+
+            if ($response->successful()) {
+                $rates = $response->json()['rates'];
+
+                return [
+                    'USD' => round($priceInCOP * $rates['USD'], 2),
+                    'EUR' => round($priceInCOP * $rates['EUR'], 2),
+                ];
+            }
+
+            return ['USD' => null, 'EUR' => null];
+
+        } catch (Exception $e) {
+            Log::error('Error fetching exchange rates: '.$e->getMessage());
+
+            return ['USD' => null, 'EUR' => null];
+        }
+    }
+}

--- a/resources/views/product/show.blade.php
+++ b/resources/views/product/show.blade.php
@@ -66,7 +66,27 @@
                                     <tbody>
                                         <tr>
                                             <th>{{ __('app.products.show.price') }}</th>
-                                            <td>${{ number_format($viewData['product']->getPrice(), 2) }}</td>
+                                            <td>${{ number_format($viewData['product']->getPrice(), 2) }} COP</td>
+                                        </tr>
+                                        <tr>
+                                            <th>USD</th>
+                                            <td>
+                                                @if($viewData['convertedPrices']['USD'])
+                                                    ${{ number_format($viewData['convertedPrices']['USD'], 2) }} USD
+                                                @else
+                                                    <span class="text-muted">N/A</span>
+                                                @endif
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <th>EUR</th>
+                                            <td>
+                                                @if($viewData['convertedPrices']['EUR'])
+                                                    €{{ number_format($viewData['convertedPrices']['EUR'], 2) }} EUR
+                                                @else
+                                                    <span class="text-muted">N/A</span>
+                                                @endif
+                                            </td>
                                         </tr>
                                         <tr>
                                             <th>{{ __('app.products.show.category') }}</th>


### PR DESCRIPTION
Se implementa el consumo de una API de terceros para convertir el precio de los productos desde pesos colombianos (COP) a dólares (USD) y euros (EUR).

Cambios principales:

Se creó la utilidad CurrencyConverter para obtener las tasas de cambio desde un servicio externo.
Se actualizó ProductController para enviar los valores convertidos a la vista de detalle del producto.
Se modificó product/show.blade.php para mostrar el precio original en COP y sus conversiones a USD y EUR.
Se ejecutó Laravel Pint para corregir el formato del código.